### PR TITLE
libvirt::params::unix_sock_dir doesnt exist in params

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -48,7 +48,7 @@ class libvirt (
   $auth_unix_ro              = $::libvirt::params::auth_unix_ro,
   $unix_sock_rw_perms        = $::libvirt::params::unix_sock_rw_perms,
   $auth_unix_rw              = $::libvirt::params::auth_unix_rw,
-  $unix_sock_dir             = $::libvirt::params::unix_sock_dir,
+  $unix_sock_dir             = undef,
   # qemu.conf options
   $qemu_vnc_listen           = undef,
   $qemu_vnc_sasl             = undef,


### PR DESCRIPTION
 Unknown variable: '::libvirt::params::unix_sock_dir'
doesnt exist in params.pp