### PR TITLE
libvirt::params::unix_sock_dir doesnt exist

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -44,7 +44,7 @@ class libvirt (
   $auth_tcp                  = undef,
   $auth_tls                  = undef,
   $unix_sock_group           = $::libvirt::params::unix_sock_group,
-  $unix_sock_ro_perms        = $::libvirt::params::unix_sock_ro_perms,
+  $unix_sock_ro_perms        = undef,
   $auth_unix_ro              = $::libvirt::params::auth_unix_ro,
   $unix_sock_rw_perms        = $::libvirt::params::unix_sock_rw_perms,
   $auth_unix_rw              = $::libvirt::params::auth_unix_rw,


### PR DESCRIPTION
 Unknown variable: '::libvirt::params::unix_sock_dir'